### PR TITLE
Removed line 101 which will throw an error

### DIFF
--- a/predicting_crime.py
+++ b/predicting_crime.py
@@ -98,7 +98,6 @@ definition_list_dayyear = dayyear_var[1]
 #set X and Y:
 
 X = df2.drop(['MCI'],axis=1).values #sets x and converts to an array
-print(X.head())
 
 y = df2['MCI'].values #sets y and converts to an array
 


### PR DESCRIPTION
#set X and Y:

X = df2.drop(['MCI'],axis=1).values #sets x and converts to an array print(X.head())

Here, the print statement would result in an error because X is an array. Using head() on arrays is not permissible due to its incompatible nature with array types.